### PR TITLE
add in case insensitive key and contract name search

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.github.hjubb"
-val versionString = "0.4.0"
+val versionString = "0.5.0"
 version = versionString
 
 val binomVersion = "0.1.22"

--- a/src/commonMain/kotlin/com/github/hjubb/solt/main.kt
+++ b/src/commonMain/kotlin/com/github/hjubb/solt/main.kt
@@ -27,6 +27,10 @@ fun main(args: Array<String>) {
             println("solt version: ${BuildKonfig.version}")
         }
     } catch (e: Exception) {
-        println("${e::class.simpleName} ${e.message}")
+        if (Environment.getEnv("DEBUG") != null) {
+            e.printStackTrace()
+        } else {
+            println("${e::class.simpleName} ${e.message}")
+        }
     }
 }

--- a/src/commonMain/kotlin/com/github/hjubb/solt/model.kt
+++ b/src/commonMain/kotlin/com/github/hjubb/solt/model.kt
@@ -5,7 +5,23 @@ import kotlinx.serialization.json.JsonObject
 import pw.binom.io.file.File
 
 @Serializable
-data class Content(val content: String)
+data class Content(val content: String) {
+
+    companion object {
+        val contractRegex =
+            Regex("contract (\\w+)")
+    }
+
+    fun findContractName() : String? {
+        return content.lineSequence()
+            .mapNotNull {
+                contractRegex.find(it)
+            }
+            .map { result ->
+                result.groups[1]!!.value
+            }.firstOrNull()
+    }
+}
 
 @Serializable
 data class BigSolInput(


### PR DESCRIPTION
fixes #1 

this implementation will case insensitive search the keys in the solc json first, and if no matches are found, will try to match against found "contract _____" in the sources. Submitted contract names to Etherscan are still able to be renamed using the `searchName:remappedName` syntax as contract name param