### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Optional flags
 * `--output` [string] Output file name (defaults to solc-input-[file].json)
 * `--help` `-h` Usage info
 
+Note that you are expected to run this from the root of your Solidity project. That is, from the same directory where "node_modules" can be found. Otherwise, certain features like the `--npm` flag will not work.
+
 ### Verify
 
 Verifies contract on [etherscan](https://etherscan.io)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Optional flags:
 ```bash
 git clone https://github.com/MainframeHQ/mainframe-lending-protocol.git /tmp/example
 cd /tmp/example
-npm install # installs node dependencies as mainframe uses openzepplin contracts
+yarn install # installs node dependencies
 
 solt write contracts --npm
 


### PR DESCRIPTION
Two changes:

+ Mention that `solt` must be run from the root of the Solidity project, which fixes #8
+ Use `yarn` instead of `npm` in the usage example (btw thanks for using our repository as a showcase)